### PR TITLE
fix: correct body tag syntax and ensure setup function is called on load

### DIFF
--- a/app/templates/createItem.html
+++ b/app/templates/createItem.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
 </head>
 
-<body>
+<body onload="setup()"">
     <header>
         <div class="logo-container purple-logo">
             <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 50 50" fill="none">
@@ -65,7 +65,7 @@
         <p>Please fill in all required fields</p>
         <button onclick="document.getElementById('error').close();">close</button>
     </dialog>
-</body onload="setup()">
+</body>
 <script>
     environment = {};
     const API_URL = `${window.location.origin}`;


### PR DESCRIPTION
This pull request includes a small change to the `app/templates/createItem.html` file. The change ensures that the `setup()` function is called when the page loads by adding an `onload` attribute to the `<body>` tag.

Changes in `app/templates/createItem.html`:

* Added `onload="setup()"` attribute to the `<body>` tag to ensure the `setup()` function is called when the page loads.
* Removed incorrect `onload="setup()"` attribute from the closing `</body>` tag.